### PR TITLE
Swik-692 delete user to deactivate user

### DIFF
--- a/application/models/user.js
+++ b/application/models/user.js
@@ -82,6 +82,9 @@ const user = {
     },
     organization: {
       type: 'string'
+    },
+    deactivated: {
+      type: 'boolean'
     }
   },
   required: ['email', 'username', 'frontendLanguage']

--- a/application/routes.js
+++ b/application/routes.js
@@ -418,6 +418,14 @@ module.exports = function (server) {
             },
             ' 404 ': {
               'description': 'The email is not used by a user.',
+            },
+            ' 401 ': {
+              'description': 'User is deactivated.',
+              'headers': {
+                'WWW-Authenticate': {
+                  'description': 'Contact the server admin in order to re-activate your account.'
+                }
+              }
             }
           },
           payloadType: 'json'

--- a/application/tests/unit_handler.js
+++ b/application/tests/unit_handler.js
@@ -303,5 +303,48 @@ describe('User service', () => {
         expect(1).to.equals(2);
       });
     });
+
+    it('Login with deleted user', () => {
+      let req = {
+        payload: {
+          email: correct_user1.email,
+          password: correct_user1.password
+        }
+      };
+      return handler.login(req, (result) => {
+        // console.log('result', result);
+
+        expect(result.isBoom).to.equal(true);
+        expect(result.output.statusCode).to.equal(401);
+
+        return;
+      })
+      .catch((Error) => {
+        console.log('Error', Error);
+        throw Error;
+        expect(1).to.equals(2);
+      });
+    });
+    it('Get deleted user as public', () => {
+      //first with _id
+      let req = {
+        params: {
+          identifier: userid
+        }
+      };
+      return handler.getPublicUser(req, (result) => {
+        // console.log(result);
+
+        expect(result.isBoom).to.equal(true);
+        expect(result.output.statusCode).to.equal(401);
+
+        return;
+      })
+      .catch((Error) => {
+        console.log('Error', Error);
+        throw Error;
+        expect(1).to.equals(2);
+      });
+    });
   });
 });


### PR DESCRIPTION
Remarks:
-     The other services are not aware of this! When using the frontend this is no problem.
-     Just login, deleteUser, getUser, getPublicUser handling this attribute. I think for the trial this is enough.
-     A user could be re-activated if someone access the database. There is no API for this
