### PR TITLE
SWIK-1131_fix_group_management

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -630,14 +630,28 @@ module.exports = {
       userid: userid
     };
 
+    let referenceDateTime = util.parseAPIParameter(req.payload.referenceDateTime) || (new Date()).toISOString();
+    delete group.referenceDateTime;
+
     group.description = util.parseAPIParameter(group.description);
     group.name = util.parseAPIParameter(group.name);
-    group.timestamp = util.parseAPIParameter(group.timestamp) || (new Date()).toISOString();
+    group.timestamp = util.parseAPIParameter(group.timestamp);
+
+    if (group.timestamp === undefined || group.timestamp === null || group.timestamp === '')
+      group.timestamp = referenceDateTime;
 
     if (group.isActive !== false)
       group.isActive = true;
     if (group.members === undefined || group.members === null || group.members.length < 0)
       group.members = [];
+
+    //add joined attribute if not given
+    group.members = group.members.reduce((array, user) => {
+      if (user.joined === undefined || user.joined === '')
+        user.joined = referenceDateTime;
+      array.push(user);
+      return array;
+    }, []);
 
     if (group.id === undefined || group.id === null) {
       //create

--- a/application/routes.js
+++ b/application/routes.js
@@ -897,11 +897,12 @@ module.exports = function (server) {
           name: Joi.string(),
           description: Joi.string().allow('').optional(),
           isActive: Joi.boolean().optional(),
-          timestamp: Joi.string(),
+          timestamp: Joi.string().allow('').optional(),
           members: Joi.array().items(Joi.object().keys({
             userid: Joi.number(),
-            joined: Joi.string()
-          }).requiredKeys('userid', 'joined'))
+            joined: Joi.string().allow('').optional()
+          }).requiredKeys('userid')),
+          referenceDateTime: Joi.string().allow('').optional()
         }).requiredKeys('name'),
         headers: Joi.object({
           '----jwt----': Joi.string().required().description('JWT header provided by /login')


### PR DESCRIPTION
Made timestamp and joined optional in route /usergroup/createorupdate. Also there could be a reference datetime, because on the server could be a different timezone