### PR TITLE
SWIQ-1100 hash password on server as well

### DIFF
--- a/application/common.js
+++ b/application/common.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const JSSHA = require('js-sha512');
+const config = require('./config.json');
 
 module.exports = {
   isEmpty: function(toTest) {

--- a/application/common.js
+++ b/application/common.js
@@ -1,6 +1,8 @@
 /* some common functions that can be used everywhere inside the program*/
 'use strict';
 
+const JSSHA = require('js-sha512');
+
 module.exports = {
   isEmpty: function(toTest) {
     return (toTest === undefined ||
@@ -16,6 +18,10 @@ module.exports = {
       delete o._id;
     }
     return o;
+  },
+
+  hashPassword: function(input){
+    return JSSHA.sha512(input + config.SALT);
   },
 
   parseAjvValidationErrors: function(array) {

--- a/application/common.js
+++ b/application/common.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const JSSHA = require('js-sha512');
-const config = require('./configuration.json');
+const config = require('./configuration.js');
 
 module.exports = {
   isEmpty: function(toTest) {

--- a/application/common.js
+++ b/application/common.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const JSSHA = require('js-sha512');
-const config = require('./configuration.js');
 
 module.exports = {
   isEmpty: function(toTest) {
@@ -21,7 +20,7 @@ module.exports = {
     return o;
   },
 
-  hashPassword: function(input, salt = config.SALT){
+  hashPassword: function(input, salt){
     return JSSHA.sha512(input + salt);
   },
 

--- a/application/common.js
+++ b/application/common.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const JSSHA = require('js-sha512');
-const config = require('./config.json');
+const config = require('./configuration.json');
 
 module.exports = {
   isEmpty: function(toTest) {

--- a/application/common.js
+++ b/application/common.js
@@ -21,8 +21,8 @@ module.exports = {
     return o;
   },
 
-  hashPassword: function(input){
-    return JSSHA.sha512(input + config.SALT);
+  hashPassword: function(input, salt = config.SALT){
+    return JSSHA.sha512(input + salt);
   },
 
   parseAjvValidationErrors: function(array) {

--- a/application/configuration.js
+++ b/application/configuration.js
@@ -1,7 +1,7 @@
 /* This module is used for configurating the mongodb connection*/
 'use strict';
 
-const co = require('./common');
+const co = require('./common.js');
 
 let host = 'localhost';
 //read mongo URL from /etc/hosts

--- a/application/configuration.js
+++ b/application/configuration.js
@@ -70,10 +70,10 @@ module.exports = {
   },
   SMTP: {
     APIKey: APIKey,
-    salt: '6cee6c6a420e0573d1a4ad8ecb44f2113d010a0c3aadd3c1251b9aa1406ba6a3',
     host: SMTP_host,
     port: SMTP_port,
     clientName: SMTP_clientName,
     from: SMTP_from
-  }
+  },
+  SALT: '6cee6c6a420e0573d1a4ad8ecb44f2113d010a0c3aadd3c1251b9aa1406ba6a3' //must be the same as in slidewiki-platform, see handler.js resetPassword
 };

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -23,7 +23,7 @@ module.exports = {
       forename: util.parseAPIParameter(req.payload.forename),
       username: util.parseAPIParameter(req.payload.username),
       email:    util.parseAPIParameter(req.payload.email).toLowerCase().replace(/\s/g,''),
-      password: co.hashPassword(util.parseAPIParameter(req.payload.password)),
+      password: co.hashPassword(util.parseAPIParameter(req.payload.password), config.SALT),
       frontendLanguage: util.parseAPIParameter(req.payload.language),
       country: '',
       picture: '',
@@ -81,7 +81,7 @@ module.exports = {
   login: (req, res) => {
     const query = {
       email: new RegExp(decodeURI(req.payload.email).replace(/\s/g,''), 'i'),
-      password: co.hashPassword(decodeURI(req.payload.password))
+      password: co.hashPassword(decodeURI(req.payload.password), config.SALT)
     };
     console.log('try logging in with email', query.email);
 
@@ -195,8 +195,8 @@ module.exports = {
 
   //User profile
   updateUserPasswd: (req, res) => {
-    let oldPassword = co.hashPassword(req.payload.oldPassword);
-    let newPassword = co.hashPassword(req.payload.newPassword);
+    let oldPassword = co.hashPassword(req.payload.oldPassword, config.SALT);
+    let newPassword = co.hashPassword(req.payload.newPassword, config.SALT);
     const user__id = util.parseStringToInteger(req.params.id);
 
     //check if the user which should be updated have the right JWT data
@@ -489,9 +489,9 @@ module.exports = {
 
       const newPassword = require('crypto').randomBytes(9).toString('hex');
       /* The password is hashed one time at the client site (inner hash and optional) and one time at server-side. As we currently only have one salt, it must be the same for slidewiki-platform and the user-service. In case this is splitted, the user-service must know both salts in order to be able to generate a valid password for resetPassword.*/
-      let hashedPassword = co.hashPassword(newPassword);
+      let hashedPassword = co.hashPassword(newPassword, config.SALT);
       if (salt && salt.length > 0)
-        hashedPassword = co.hashPassword(co.hashPassword(newPassword, salt));
+        hashedPassword = co.hashPassword(co.hashPassword(newPassword, salt), config.SALT);
 
       console.log('resetPassword: email is in use thus we connect to the SMTP server');
 

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -23,7 +23,7 @@ module.exports = {
       forename: util.parseAPIParameter(req.payload.forename),
       username: util.parseAPIParameter(req.payload.username),
       email:    util.parseAPIParameter(req.payload.email).toLowerCase().replace(/\s/g,''),
-      password: util.parseAPIParameter(req.payload.password),
+      password: co.hashPassword(util.parseAPIParameter(req.payload.password)),
       frontendLanguage: util.parseAPIParameter(req.payload.language),
       country: '',
       picture: '',
@@ -81,7 +81,7 @@ module.exports = {
   login: (req, res) => {
     const query = {
       email: new RegExp(decodeURI(req.payload.email).replace(/\s/g,''), 'i'),
-      password: decodeURI(req.payload.password)
+      password: co.hashPassword(decodeURI(req.payload.password))
     };
     console.log('try logging in with email', query.email);
 
@@ -195,8 +195,8 @@ module.exports = {
 
   //User profile
   updateUserPasswd: (req, res) => {
-    let oldPassword = req.payload.oldPassword;
-    let newPassword = req.payload.newPassword;
+    let oldPassword = co.hashPassword(req.payload.oldPassword);
+    let newPassword = co.hashPassword(req.payload.newPassword);
     const user__id = util.parseStringToInteger(req.params.id);
 
     //check if the user which should be updated have the right JWT data
@@ -487,7 +487,8 @@ module.exports = {
       }
 
       const newPassword = require('crypto').randomBytes(9).toString('hex');
-      const hashedPassword = JSSHA.sha512(newPassword + config.SMTP.salt);
+      /* The password is hasehd one time at the client site (inner hash) and one time at server-side. As we currently only have one salt, it must be the same for slidewiki-platform and the user-service. In case this is splitted, the user-service must know both salts in order to be able to generate a valid password for resetPassword.*/
+      const hashedPassword = co.hashPassword(co.hashPassword(newPassword));
 
       console.log('resetPassword: email is in use thus we connect to the SMTP server');
 

--- a/application/db_migration_hashing.js
+++ b/application/db_migration_hashing.js
@@ -1,0 +1,45 @@
+/*
+This script updates the passwords of all users by hashing it (with the provided salt) - only execute this once, outherwise passwords are broken!
+ */
+
+'use strict';
+
+const co = require('./common'),
+  userDB = require('./database/user'),
+  JSSHA = require('js-sha512'),
+  async = require('async');
+
+let salt = '';
+
+console.log('\x1b[31m','This script updates the passwords of all users by hashing it (with the provided salt) - only execute this once, outherwise passwords are broken!','\x1b[0m');//strange stuff for red color
+
+if(process.argv.length < 3 || process.argv.length > 3){
+  console.log('To few (or many) arguments, please provide only a salt as an argument!');
+  process.exit(1);
+} else
+  salt = process.argv[2];
+
+userDB.find({})
+.then((cursor) => {
+  cursor.count().then((count) => console.log(count + ' users found, starting migration ...'));
+  let q = async.queue((user, callback) => {
+    let hashedPassword = JSSHA.sha512(user.password + salt);
+    userDB.partlyUpdate({'_id': user._id}, {'$set': {'password': hashedPassword}}).then(() => {
+      process.stdout.write('\rUpdated user ' + user._id + ' (out of order)');
+      callback();
+    });
+  }, Infinity);
+
+  cursor.forEach((user) => {
+    if(!co.isEmpty(user)){
+      q.push(user);
+    }
+  });
+  q.drain = function() {
+    if (cursor.isClosed()) {
+      console.log('\n');
+      console.log('All Users have been updated');
+      process.exit(0);
+    }
+  };
+});

--- a/application/db_migration_hashing.js
+++ b/application/db_migration_hashing.js
@@ -22,6 +22,7 @@ if(process.argv.length < 3 || process.argv.length > 3){
 userDB.find({})
 .then((cursor) => {
   cursor.count().then((count) => console.log(count + ' users found, starting migration ...'));
+  // I haven't found any other way to implement it than this one, maybe except for lazy evaluation via yield
   let q = async.queue((user, callback) => {
     let hashedPassword = JSSHA.sha512(user.password + salt);
     userDB.partlyUpdate({'_id': user._id}, {'$set': {'password': hashedPassword}}).then(() => {

--- a/application/db_migration_hashing.js
+++ b/application/db_migration_hashing.js
@@ -32,7 +32,7 @@ userDB.find({})
   }, Infinity);
 
   cursor.forEach((user) => {
-    if(!co.isEmpty(user)){
+    if(!co.isEmpty(user) && user.passord && user._id){
       q.push(user);
     }
   });

--- a/application/db_migration_hashing.js
+++ b/application/db_migration_hashing.js
@@ -32,7 +32,7 @@ userDB.find({})
   }, Infinity);
 
   cursor.forEach((user) => {
-    if(!co.isEmpty(user) && user.passord && user._id){
+    if(!co.isEmpty(user) && user.password && user._id){
       q.push(user);
     }
   });

--- a/application/package.json
+++ b/application/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "ajv": "^4.11.0",
+    "async": "^2.4.0",
     "boom": "^4.2.0",
     "database-cleaner": "^1.2.0",
     "good": "^7.1.0",
@@ -40,10 +41,10 @@
     "js-sha512": "^0.2.2",
     "mongodb": "^2.2.22",
     "purest": "2.0.1",
-    "yar": "^8.1.0",
     "request": "^2.78.0",
     "smtp-connection": "^2.12.0",
-    "vision": "^4.1.1"
+    "vision": "^4.1.1",
+    "yar": "^8.1.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/application/routes.js
+++ b/application/routes.js
@@ -461,7 +461,8 @@ module.exports = function (server) {
         payload: {
           email: Joi.string().email(),
           language: Joi.string().length(5),
-          APIKey: Joi.string().alphanum()
+          APIKey: Joi.string().alphanum().description('Client specific key. Is needed to use this route.'),
+          salt: Joi.string().allow('').optional().description('When this parameter is given, then the service assume that the client will hash the users plaintext password with SHA-512(password + salt)')
         }
       },
       tags: ['api'],


### PR DESCRIPTION
I've implemented password hashing on server side + a migration script to migrate all registered users. This uses the same salt as the one that is used at slidewiki/platform. Is this okay or should it use another salt, that is different?
Please review the migration script carefully!