### PR TITLE
Add 'system' static user as recognizable to the user service

### DIFF
--- a/application/controllers/util.js
+++ b/application/controllers/util.js
@@ -18,6 +18,16 @@ module.exports = {
 
   isIdentityAssigned: (email, username) => {
     let myPromise = new Promise((resolve, reject) => {
+      // check for static users!!
+      let staticUser = userCtrl.findStaticUserByName(username);
+      if (staticUser) {
+        return resolve({
+          assigned: true,
+          username: true,
+          email: false,
+        });
+      }
+
       return userCtrl.find({
         $or: [
           {

--- a/application/database/user.js
+++ b/application/database/user.js
@@ -99,7 +99,7 @@ let self = module.exports = {
 
   findStaticUsersByIds: function(userids) {
     if (!userids) return [];
-    return staticUsers.filter((u) => userids.some((id) => (id === u._id)));
+    return staticUsers.filter((u) => userids.includes(u._id));
   },
 
   // check username against static users array

--- a/application/database/user.js
+++ b/application/database/user.js
@@ -4,7 +4,20 @@ const helper = require('./helper'),
   userModel = require('../models/user.js'),
   collectionName = 'users';
 
-module.exports = {
+// hardcoded (static) users
+// the attributes included are only the public user attributes needed
+const staticUsers = [
+  {
+    _id: -1,
+    username: 'system',
+    organization: '',
+    picture: '',
+    description: 'This is a reserved system account',
+    country: '',
+  },
+];
+
+let self = module.exports = {
   create: (user) => {
     return helper.connectToDatabase()
       .then((dbconn) => helper.getNextIncrementationValueForCollection(dbconn, collectionName))
@@ -75,5 +88,29 @@ module.exports = {
     return helper.connectToDatabase()
       .then((dbconn) => dbconn.collection(collectionName))
       .then((collection) => collection.update(findQuery, updateQuery, params));
-  }
+  },
+
+  findStaticUserById: function(userid) {
+    // return nothing if non-static or unknown
+    if (userid > 0) return null;
+    // maybe null
+    return staticUsers.find((u) => u._id === userid);
+  },
+
+  findStaticUsersByIds: function(userids) {
+    if (!userids) return [];
+    return staticUsers.filter((u) => userids.some((id) => (id === u._id)));
+  },
+
+  // check username against static users array
+  findStaticUserByName: function(username) {
+    if (!username) return null;
+    // maybe null
+    return staticUsers.find((u) => u.username === username.toLowerCase());
+  },
+
+  findStaticUser: function(query) {
+    return self.findStaticUserByName(query.username) || self.findStaticUserById(query._id);
+  },
+
 };

--- a/application/tests/integration_information.js
+++ b/application/tests/integration_information.js
@@ -142,6 +142,21 @@ describe('REST API', () => {
       });
     });
 
+    it('it should reply that the `system` username is already used and tell similar used usernames', () => {
+      let opt = JSON.parse(JSON.stringify(options2));
+      opt.url += 'system';
+      return server.inject(opt).then((response) => {
+        response.should.be.an('object').and.contain.keys('statusCode', 'payload');
+        response.statusCode.should.equal(200);
+        response.payload.should.be.a('string');
+        let payload = JSON.parse(response.payload);
+        payload.should.be.an('object').and.contain.keys('taken', 'alsoTaken');
+        payload.taken.should.be.a('boolean').and.equal(true);
+        payload.alsoTaken.should.be.an('array').and.be.not.empty;
+        payload.alsoTaken.should.contain('system');
+      });
+    });
+
     it('it should reply that a username is not used in case it is not in use', () => {
       let opt = JSON.parse(JSON.stringify(options2));
       opt.url += 'hero';
@@ -203,6 +218,34 @@ describe('REST API', () => {
       });
     });
 
+    it('it should reply that the `system` username is not a registered user', () => {
+      let opt = JSON.parse(JSON.stringify(options3));
+      opt.url += 'system';
+      return server.inject(opt).then((response) => {
+        response.should.be.an('object').and.contain.keys('statusCode', 'payload');
+        response.statusCode.should.equal(200);
+        response.payload.should.be.a('string');
+        let payload = JSON.parse(response.payload);
+        payload.should.be.an('object').and.contain.keys('success', 'results');
+        payload.success.should.be.a('boolean').and.equal(true);
+        payload.results.should.be.an('array').and.be.empty;
+      });
+    });
+
+    it('it should not return the `system` username as a registered user when searching with string `sys`', () => {
+      let opt = JSON.parse(JSON.stringify(options3));
+      opt.url += 'sys';
+      return server.inject(opt).then((response) => {
+        response.should.be.an('object').and.contain.keys('statusCode', 'payload');
+        response.statusCode.should.equal(200);
+        response.payload.should.be.a('string');
+        let payload = JSON.parse(response.payload);
+        payload.should.be.an('object').and.contain.keys('success', 'results');
+        payload.success.should.be.a('boolean').and.equal(true);
+        payload.results.should.be.an('array').and.not.include('system');
+      });
+    });
+
     // it('it should return 400 in case the username parameter is missing', () => {  //TODO 200 with emtpy array should be returned
     //   let opt = JSON.parse(JSON.stringify(options3));
     //   return server.inject(opt).then((response) => {
@@ -228,6 +271,20 @@ describe('REST API', () => {
         payload._id.should.be.a('number').and.equal(1);
         payload.username.should.be.an('string').and.equal(fullData.username);
         payload.organization.should.be.an('string').and.equal(fullData.organization);
+      });
+    });
+
+    it('it should reply the public user information for the `system` user', () => {
+      let opt = JSON.parse(JSON.stringify(options4));
+      opt.url += 'system';
+      return server.inject(opt).then((response) => {
+        response.should.be.an('object').and.contain.keys('statusCode', 'payload');
+        response.statusCode.should.equal(200);
+        response.payload.should.be.a('string');
+        let payload = JSON.parse(response.payload);
+        payload.should.be.an('object').and.contain.keys('_id', 'username', 'country', 'picture', 'description', 'organization');
+        payload._id.should.be.a('number').and.equal(-1);
+        payload.username.should.be.an('string').and.equal('system');
       });
     });
 

--- a/application/tests/integration_register.js
+++ b/application/tests/integration_register.js
@@ -114,5 +114,24 @@ describe('REST API', () => {
       });
     });
 
+    it('it should return 409 about the static `system` user', () => {
+      let opt = JSON.parse(JSON.stringify(options));
+      opt.payload = {
+        username: 'system',
+        email: 'system@test.test',
+        password: '12345678',
+        language: 'en_EN',
+      };
+      return server.inject(opt).then((response) => {
+        // console.log('testresult:', response.statusCode, response.payload);
+        response.should.be.an('object').and.contain.keys('statusCode','payload');
+        response.statusCode.should.equal(409);
+        response.payload.should.be.a('string');
+        let payload = JSON.parse(response.payload);
+        payload.should.be.an('object').and.contain.keys('statusCode', 'error', 'message');
+        payload.error.should.be.a('string').and.equal('Conflict');
+      });
+    });
+
   });
 });

--- a/application/tests/unit_database_user.js
+++ b/application/tests/unit_database_user.js
@@ -100,4 +100,37 @@ describe('User service database', () => {
         });
     });
   });
+
+  context('When accessing static users', () => {
+
+    it('should recognise `system` user with id equal to `-1`', () => {
+      let user = db.findStaticUserById(-1);
+      expect(user).to.be.an('object').that.has.property('username', 'system');
+    });
+
+    it('should only find `system` user when requesting static users with various ids', () => {
+      let users = db.findStaticUsersByIds([-1, -2, 0, 666]);
+      expect(users).to.be.an('array').that.has.lengthOf(1);
+      expect(users[0]).to.be.an('object').that.has.property('username', 'system');
+    });
+
+    it('should recognise `system` user by its name', () => {
+      let user = db.findStaticUserByName('system');
+      expect(user).to.be.an('object').that.has.property('_id', -1);
+    });
+
+    it('should recognise `system` user by its name or id', () => {
+      let user = db.findStaticUser({ username: 'system1', _id: -1 });
+      expect(user).to.be.an('object');
+      expect(user).to.have.property('username', 'system');
+      expect(user).to.have.property('_id', -1);
+
+      user = db.findStaticUser({ username: 'system', _id: 5 });
+      expect(user).to.be.an('object');
+      expect(user).to.have.property('username', 'system');
+      expect(user).to.have.property('_id', -1);
+    });
+
+  });
+
 });

--- a/application/tests/unit_handler.js
+++ b/application/tests/unit_handler.js
@@ -121,6 +121,20 @@ describe('User service', () => {
       }
     ]
   };
+
+  // this user should be rejected by register function
+  const wrong_user1 = {
+    username: 'system',
+    forename: 'Kostis',
+    surname: 'Pristouris',
+    email: 'kprist@gmail.com',
+    password: '812408917221308476234',
+    language: 'el',
+    defaults: [{
+      language: 'el'
+    }]
+  };
+
   const newPassword = 'ua89nd7s8df7zsb78f';
   let userid = '',
     jwt = '',
@@ -165,6 +179,12 @@ describe('User service', () => {
         expect(1).to.equals(2);
       });
     });
+    it('Should not allow a user to register with username `system`', () => {
+      return handler.register({ payload: wrong_user1 }, (result) => {
+        expect(result).to.be.an('error').that.has.property('isBoom', true);
+        expect(result).to.have.deep.property('output.statusCode', 409);
+      });
+    });
     it('Get user public', () => {
       //first with _id
       let req = {
@@ -194,6 +214,23 @@ describe('User service', () => {
         console.log('Error', Error);
         throw Error;
         expect(1).to.equals(2);
+      });
+    });
+    it('Should return public info for `system` static user', () => {
+
+      return handler.getPublicUser({ params: { identifier: '-1' } }, (result) => {
+        // first with id
+        expect(result).to.be.an('object');
+        expect(result).to.have.property('_id', -1);
+        expect(result).to.have.property('username', 'system');
+
+        return handler.getPublicUser({ params: { identifier: 'system' } }, (result) => {
+          // then with name
+          expect(result).to.be.an('object');
+          expect(result).to.have.property('_id', -1);
+          expect(result).to.have.property('username', 'system');
+        });
+
       });
     });
     it('Login with user', () => {
@@ -371,6 +408,13 @@ describe('User service', () => {
         console.log('Error', Error);
         throw Error;
         expect(1).to.equals(2);
+      });
+    });
+    it('Should check `system` username and report it as taken', () => {
+      return handler.checkUsername({ params: { username: 'system' } }, (result) => {
+        // should be taken
+        expect(result).to.be.an('object').that.has.property('taken', true);
+        expect(result.alsoTaken).to.be.an('array').that.is.not.empty;
       });
     });
 


### PR DESCRIPTION
This affects results in the following API endpoints:
* GET /user/{identifier}
* GET /information/username/{username}
* POST /users

It does not affect behaviour of
  GET /information/username/search/{username}
as that call is used to browse available users e.g. for assigning to
groups or to deck edit rights, so we don't want static users to be
listed there.

It also affects behaviour of POST /register, as it double checks for
already taken usernames in static users as well.