### PR TITLE
SWIK-1738_suspended_user_return

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -465,11 +465,6 @@ module.exports = {
           return res(boom.locked('User is not authorised yet.'));
         }
 
-        //check if SPAM
-        if (array[0].suspended === true) {
-          return res(boom.forbidden('The user is marked as SPAM.'));
-        }
-
         res(preparePublicUserData(array[0]));
       })
       .catch((error) => {
@@ -1424,7 +1419,7 @@ function prepareDetailedUserData(user) {
 
 //Remove attributes of the user data object which should not be transmitted for the user profile
 function preparePublicUserData(user) {
-  const shownKeys = ['_id', 'username', 'organization', 'picture', 'description', 'country'];
+  const shownKeys = ['_id', 'username', 'organization', 'picture', 'description', 'country', 'suspended'];
   let minimizedUser = {};
 
   let key;

--- a/application/routes.js
+++ b/application/routes.js
@@ -381,9 +381,6 @@ module.exports = function (server) {
             ' 200 ': {
               'description': 'Successful',
             },
-            ' 403 ': {
-              'description': 'The user is marked as SPAM.',
-            },
             ' 404 ': {
               'description': 'User not found. Check the id.'
             },


### PR DESCRIPTION
Altered routes for returning suspended users when public profile was requested with the included attribute suspended

POST /users and GET /user/{identifier} were changed