### PR TITLE
SWIK-1949_social_login_null_attributes

### DIFF
--- a/application/controllers/handler_social.js
+++ b/application/controllers/handler_social.js
@@ -54,6 +54,12 @@ module.exports = {
           identifier: user.identifier
         };
 
+        //remove null values
+        for (let key in data) {
+          if (data[key] === null)
+            data[key] = undefined;
+        }
+
         // console.log('handleOAuth2Token: created data', data);
 
         return providerCtrl.create(data)


### PR DESCRIPTION
Added that null values are set to undefined when provider data was gathered. Such null values gave an error when validating the user data model with ajv.

Its quite hard to test because it just happend with one user. If you want to test it by yourself I will provide you test code and a Github Token of the user.